### PR TITLE
在Docker CI构建时添加对Linux/ARM64平台的支持

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -38,6 +38,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/blrec:latest,${{ secrets.DOCKER_HUB_USERNAME }}/blrec:${{ github.ref_name }}
           cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
根据隔壁录播组的需求，我修改了Github Actions中Docker镜像的构建参数，以添加对于`Linux/ARM64`平台的支持。
https://github.com/VTB-LINK/blrec/blob/652781fa1f7d99638850a3cbac0a88a633f94ab0/.github/workflows/docker-hub.yml#L41

本修改参考了：
- https://docs.docker.com/build/ci/github-actions/multi-platform/