### PR TITLE
suppress exceptions of calling malloc_trim

### DIFF
--- a/src/blrec/utils/libc.py
+++ b/src/blrec/utils/libc.py
@@ -1,9 +1,9 @@
+from contextlib import suppress
 from ctypes import cdll
 from ctypes.util import find_library
-from sys import platform
 
 lib_name = find_library('c')
-if not lib_name or platform != 'linux':
+if not lib_name:
     libc = None
 else:
     libc = cdll.LoadLibrary(lib_name)
@@ -14,4 +14,5 @@ def malloc_trim(pad: int) -> bool:
     assert pad >= 0, 'pad must be >= 0'
     if libc is None:
         return False
-    return libc.malloc_trim(pad) == 1
+    with suppress(Exception):
+        return libc.malloc_trim(pad) == 1

--- a/src/blrec/utils/libc.py
+++ b/src/blrec/utils/libc.py
@@ -1,8 +1,9 @@
 from ctypes import cdll
 from ctypes.util import find_library
+from sys import platform
 
 lib_name = find_library('c')
-if not lib_name:
+if not lib_name or platform != 'linux':
     libc = None
 else:
     libc = cdll.LoadLibrary(lib_name)


### PR DESCRIPTION
Call malloc_trim only on linux.
Resolves the following error:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/uvicorn/protocols/http/httptools_impl.py", line 419, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/usr/local/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/fastapi/applications.py", line 270, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.9/site-packages/blrec/web/middlewares/route_redirect.py", line 25, in __call__
    await self._app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/cors.py", line 92, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/cors.py", line 147, in simple_response
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/brotli_asgi/__init__.py", line 85, in __call__
    await gzip_responder(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/gzip.py", line 44, in __call__
    await self.app(scope, receive, self.send_with_gzip)
  File "/usr/local/lib/python3.9/site-packages/blrec/web/middlewares/base_herf.py", line 16, in __call__
    await self._app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/usr/local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 706, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 235, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 161, in run_endpoint_function
    return await dependant.call(**values)
  File "/usr/local/lib/python3.9/site-packages/blrec/web/routers/tasks.py", line 321, in remove_task
    await app.remove_task(room_id)
  File "/usr/local/lib/python3.9/site-packages/blrec/application.py", line 158, in remove_task
    await self._task_manager.remove_task(room_id)
  File "/usr/local/lib/python3.9/site-packages/blrec/task/task_manager.py", line 124, in remove_task
    malloc_trim(0)
  File "/usr/local/lib/python3.9/site-packages/blrec/utils/libc.py", line 16, in malloc_trim
    **return libc.malloc_trim(pad) == 1**
  File "/usr/local/lib/python3.9/ctypes/__init__.py", line 387, in __getattr__
    func = self.__getitem__(name)
  File "/usr/local/lib/python3.9/ctypes/__init__.py", line 392, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: **Undefined symbol "malloc_trim"**