### PR TITLE
修复断网重连以后录制无法自动恢复的问题

### DIFF
--- a/src/blrec/bili/live.py
+++ b/src/blrec/bili/live.py
@@ -172,11 +172,13 @@ class Live:
 
     async def check_connectivity(self) -> bool:
         try:
-            await self._session.head('https://live.bilibili.com/', timeout=3)
-        except (aiohttp.ClientConnectionError, asyncio.TimeoutError):
-            return False
-        else:
+            await self._session.head('https://live.bilibili.com/', timeout=3, headers={
+                'User-Agent': self._user_agent,
+            })
             return True
+        except Exception as e:
+            self._logger.warning(f'Check connectivity failed: {repr(e)}')
+            return False
 
     async def update_info(self, raise_exception: bool = False) -> bool:
         return all(


### PR DESCRIPTION
Fix #259

## 问题现象

断网触发 `ConnectionErrorHandler` 后：

- 若网络恢复，会报错 `aiohttp.client_exceptions.ClientResponseError: 412, message='Precondition Failed', url=URL('https://live.bilibili.com/')`，
- 若网络一直未恢复，`断网等待时间` 设置项不生效

## 问题原因

1. `Live` 中 `check_connectivity` 方法未捕获所有异常，若请求 `https://live.bilibili.com/` 失败，会导致异常抛出到 `ConnectionErrorHandler` 的 `_wait_for_connection_error` 导致重试与超时逻辑被打断

   https://github.com/acgnhiki/blrec/blob/8dc32e5e6ef80ec67a50e45b9d260c7403c4bb9f/src/blrec/bili/live.py#L173-L179

   https://github.com/acgnhiki/blrec/blob/8dc32e5e6ef80ec67a50e45b9d260c7403c4bb9f/src/blrec/core/operators/connection_error_handler.py#L74-L85

2. `Live` 中 `check_connectivity` 方法请求的 B 站直播首页 `https://live.bilibili.com/` 有风控策略，当请求 UA 为 python requests 的 UA（例如 `python-requests/2.31.0`）时，会拦截并返回 412 状态码，导致 `check_connectivity` 始终不能成功

   ```
   curl -v -H "User-Agent: python-requests/2.31.0" https://live.bilibili.com/
   ```

   ```
   > GET / HTTP/1.1
   > Host: live.bilibili.com
   > Accept: */*
   > User-Agent: python-requests/2.31.0
   >
   
   < HTTP/1.1 412 Precondition Failed
   < Content-Type: text/html
   < Transfer-Encoding: chunked
   < Connection: keep-alive
   < Server: openresty
   < Cache-Control: no-cache
   < X-BILI-SEC-TOKEN: 1,denied by waf mode
   <
   ```

## 修复方法

1. `check_connectivity` 请求  `https://live.bilibili.com/` 时带上用户指定的 UA
2. `check_connectivity` 捕获 requests 请求时抛出的所有异常，若有异常则返回 False 并打印异常信息到 log 当中