### PR TITLE
fix: ensure room_id scope

### DIFF
--- a/src/blrec/setting/models.py
+++ b/src/blrec/setting/models.py
@@ -315,7 +315,7 @@ class TaskOptions(BaseModel):
 
 class TaskSettings(TaskOptions):
     # must use the real room id rather than the short room id!
-    room_id: Annotated[int, Field(ge=1, lt=2**32)]
+    room_id: Annotated[int, Field(ge=1, lt=2**100)]
     enable_monitor: bool = True
     enable_recorder: bool = True
 


### PR DESCRIPTION
Sometimes, the room_id exceeds the limit of 2**32. I originally intended to change the type of room_id, but since this type is already widely used throughout the system, it's difficult to modify. So, I changed it to 2**100 to ensure that the room_id will never overflow.

--------

有时，room_id会超出2^32的上限，我本想修改roomid的类型但是该类型已经在系统内大量使用...不好修改，所以我改成了2^100，保证roomid永远不会炸